### PR TITLE
Fix syntax error that blocks migrations

### DIFF
--- a/lib/redmine_tags/patches/issue_patch.rb
+++ b/lib/redmine_tags/patches/issue_patch.rb
@@ -30,7 +30,7 @@ module RedmineTags
           # searchable_options[:columns] << "#{ ActsAsTaggableOn::Tag.table_name }.name"
           # searchable_options[:preload] << :tags
 
-          scope :on_project, -> (project) {
+          scope :on_project, ->(project) {
               project = project.id if project.is_a? Project
               where "#{ Project.table_name }.id = ?", project
             }

--- a/lib/redmine_tags/patches/wiki_page_patch.rb
+++ b/lib/redmine_tags/patches/wiki_page_patch.rb
@@ -30,7 +30,7 @@ module RedmineTags
           # searchable_options[:columns] << "#{ ActsAsTaggableOn::Tag.table_name }.name"
           # searchable_options[:preload] << :tags
 
-          scope :on_project, -> (project) {
+          scope :on_project, ->(project) {
               project = project.id if project.is_a? Project
               where "#{ Project.table_name }.id = ?", project
             }


### PR DESCRIPTION
Related: https://github.com/marius-balteanu/redmine_tags/issues/8

I'm not entirely sure why removing the space fixes it, but [this article](http://novice-ruby-gotchas.blogspot.com/2012/05/lambda-function-syntax-in-ruby-19.html) seems to shed some light on it. I was also using Ruby v1.9 like the issue author.

```
SyntaxError: /opt/wwwservices/redmine/www/plugins/redmine_tags/lib/redmine_tags/patches/issue_patch.rb:33: syntax error, unexpected tLPAREN_ARG, expecting keyword_do_LAMBDA or tLAMBEG
scope :on_project, -> (project) {
```