### PR TITLE
correcting js asset name

### DIFF
--- a/app/views/wiki/_tags_form.html.erb
+++ b/app/views/wiki/_tags_form.html.erb
@@ -6,7 +6,7 @@
 <div id="wiki_tag_candidates" class="autocomplete"></div>
 <%= stylesheet_link_tag 'jquery.tagit.css', plugin: 'redmine_tags' %>
 <%= stylesheet_link_tag 'redmine_tags', plugin: 'redmine_tags' %>
-<%= javascript_include_tag 'tag-it', plugin: 'redmine_tags' %>
+<%= javascript_include_tag 'tag-it.min', plugin: 'redmine_tags' %>
 <%= javascript_tag "$('#wiki_page_tag_list').tagit({
     tagSource: function(search, showChoices) {
       var that = this;


### PR DESCRIPTION
fix for marius-balteanu/redmine_tags#11 "wiki pages are not tagable"